### PR TITLE
주문 후 이름을 변경해도 주문자의 이름까지 바뀜

### DIFF
--- a/server/graphql/resolvers/index.js
+++ b/server/graphql/resolvers/index.js
@@ -648,7 +648,11 @@ const resolvers = {
         // 유저이름 수정
         updateUser: async (_, { _id, username }) => {
             try {
-
+                const person = await users.findById(_id).exec()
+                if(person.status = "주문완료"){
+                    const updated = await Order.find({"username":person.username}).exec()
+                    const updateorder = await Order.findByIdAndUpdate(updated[0]._id,{$set:{"username":username}})
+                }
                 return await users.findByIdAndUpdate(_id, { $set: { username } }).exec()
             } catch (error) {
                 throw new Error(error.message)


### PR DESCRIPTION
주문 후 이름을 변경하면 order의 username이 안 바뀌는 이슈를 해결하였습니다.