### PR TITLE
Tooltip 문제 해결

### DIFF
--- a/client/src/components/table/PaymentTable.js
+++ b/client/src/components/table/PaymentTable.js
@@ -45,9 +45,9 @@ function BoardTable() {
 
     return (
 
-        <Suspense fallback={<LoadingComponent loading/>}>
+        <Suspense fallback={<LoadingComponent loading/> && user}>
 
-            {content && user &&
+            {content &&
             content.map((content, index) => (
                 content !== "" && <span key={index} className={classes.content}>
                        <Tooltip title={user} placement="top">


### PR DESCRIPTION
failed props type: tooltip title을 해결하기 위해 
map에 {content && user && content.map(()=>())} 로 넣고 난 뒤
receiptUser 데이터가 늦게 들어올 경우 tooltip과 버튼이 아예 안 뜸
Suspense에 loading과 receiptuser data 넣어서 불러오고 난 후, tooltip이 뜨게 바꿈.